### PR TITLE
no need to install yarn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install yarn
-        run: npm install -g yarn
-
       - name: Install dependencies
         run: yarn
 


### PR DESCRIPTION
Corepack should make yarn available without having to explictly install it.