### PR TITLE
setup turborepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ out
 **/cypress/videos
 **/cypress/screenshots
 .swc
+
+.turbo

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     ]
   },
   "scripts": {
-    "build": "yarn workspaces foreach --since run build && yarn workspaces foreach --since run typecheck",
-    "lint": "yarn workspaces foreach --since run lint",
-    "lint:fix": "yarn workspaces foreach --since run lint:fix",
-    "test": "yarn workspaces foreach --since run run test",
+    "build:all": "turbo build",
+    "lint:all": "turbo lint",
+    "lint:fix:all": "yarn workspaces foreach --all run lint --fix",
+    "test:all": "turbo test",
     "clean": "rm -rf ./node_modules ./packages/*/node_modules"
   },
   "devDependencies": {
-    "rimraf": "^3.0.2"
+    "turbo": "^1.10.16"
   },
   "packageManager": "yarn@4.0.2"
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["^build"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"]
+    },
+    "lint": {}
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4922,7 +4922,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "cli-apps@workspace:."
   dependencies:
-    rimraf: "npm:^3.0.2"
+    turbo: "npm:^1.10.16"
   languageName: unknown
   linkType: soft
 
@@ -11062,6 +11062,77 @@ __metadata:
   version: 2.5.3
   resolution: "tslib@npm:2.5.3"
   checksum: d507e60ebe2480af4efc1655dfdb2762bb6ca57d76c4ba680375af801493648c2e97808bbd7e54691eb40e33a7e2e793cdef9c24ce6a8539b03cac8b26e09a61
+  languageName: node
+  linkType: hard
+
+"turbo-darwin-64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-darwin-64@npm:1.10.16"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-darwin-arm64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-darwin-arm64@npm:1.10.16"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo-linux-64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-linux-64@npm:1.10.16"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-linux-arm64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-linux-arm64@npm:1.10.16"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo-windows-64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-windows-64@npm:1.10.16"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-windows-arm64@npm:1.10.16":
+  version: 1.10.16
+  resolution: "turbo-windows-arm64@npm:1.10.16"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo@npm:^1.10.16":
+  version: 1.10.16
+  resolution: "turbo@npm:1.10.16"
+  dependencies:
+    turbo-darwin-64: "npm:1.10.16"
+    turbo-darwin-arm64: "npm:1.10.16"
+    turbo-linux-64: "npm:1.10.16"
+    turbo-linux-arm64: "npm:1.10.16"
+    turbo-windows-64: "npm:1.10.16"
+    turbo-windows-arm64: "npm:1.10.16"
+  dependenciesMeta:
+    turbo-darwin-64:
+      optional: true
+    turbo-darwin-arm64:
+      optional: true
+    turbo-linux-64:
+      optional: true
+    turbo-linux-arm64:
+      optional: true
+    turbo-windows-64:
+      optional: true
+    turbo-windows-arm64:
+      optional: true
+  bin:
+    turbo: bin/turbo
+  checksum: 7aca670d135dad376daaffaeef3dc24cfd53a0463b009e2870335cb6a5bfd30086217f34d7632c902f8df8391bf0a3289c1ed79ae251462de708a27db6df9f6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Sets up turbo repo for fast monorepo builds.

Scripts in the root `package.json` changed to include `build:all`, `test:all` etc, because Yarn will allow running those scripts from any folder in the monorepo, making it easy to work across packages.